### PR TITLE
Surface upstream HTTP status when body is not JSON

### DIFF
--- a/scout_mcp/scout_api.py
+++ b/scout_mcp/scout_api.py
@@ -103,18 +103,35 @@ class ScoutAPMBase(ABC):
         return {"X-SCOUT-API": self.api_key}
 
     def _handle_response_errors(self, response: httpx.Response) -> Dict[str, Any]:
-        """Handle common response errors and parse JSON."""
+        """Handle common response errors and parse JSON.
+
+        The HTTP status is checked before attempting to parse JSON so that
+        upstream failures with empty or non-JSON bodies (e.g. 502/504 from a
+        proxy in front of the Scout APM API on long time windows) surface a
+        status-aware error rather than a misleading "Invalid JSON response".
+        """
+        # 401 always means auth failure regardless of body shape.
+        if response.status_code == 401:
+            raise ScoutAPMAuthError("Authentication failed - check your API key")
+
         # Try to parse JSON response
         try:
             data = response.json()
         except json.JSONDecodeError:
+            body = response.text or "<empty>"
+            truncated = body[:500]
+            if response.status_code >= 400:
+                reason = getattr(response, "reason_phrase", "") or ""
+                raise ScoutAPMAPIError(
+                    f"Upstream returned {response.status_code} {reason}".rstrip()
+                    + f" with non-JSON body: {truncated}",
+                    response.status_code,
+                )
             raise ScoutAPMAPIError(
-                f"Invalid JSON response: {response.text}", response.status_code
+                f"Invalid JSON response (status {response.status_code}): "
+                f"{truncated}",
+                response.status_code,
             )
-
-        # Check for API-level errors
-        if response.status_code == 401:
-            raise ScoutAPMAuthError("Authentication failed - check your API key")
 
         if response.status_code >= 400:
             error_msg = "API request failed"

--- a/tests/scout_mcp/test_scout_api.py
+++ b/tests/scout_mcp/test_scout_api.py
@@ -167,6 +167,67 @@ class TestScoutAPMBase:
         with pytest.raises(ScoutAPMAPIError, match="Not found"):
             client._handle_response_errors(mock_response)
 
+    def test_handle_response_errors_504_empty_body(self):
+        """504 with empty body should surface the status, not 'Invalid JSON'."""
+        client = ScoutAPMAsync("test_key")
+        mock_response = Mock()
+        mock_response.status_code = 504
+        mock_response.reason_phrase = "Gateway Timeout"
+        mock_response.json.side_effect = json.JSONDecodeError("Expecting value", "", 0)
+        mock_response.text = ""
+
+        with pytest.raises(ScoutAPMAPIError) as exc_info:
+            client._handle_response_errors(mock_response)
+
+        message = str(exc_info.value)
+        assert "504" in message
+        assert "Gateway Timeout" in message
+        assert "<empty>" in message
+        assert "Invalid JSON" not in message
+        assert exc_info.value.status_code == 504
+
+    def test_handle_response_errors_502_html_body_truncated(self):
+        """502 with a long HTML body should surface 502 and truncate body."""
+        client = ScoutAPMAsync("test_key")
+        mock_response = Mock()
+        mock_response.status_code = 502
+        mock_response.reason_phrase = "Bad Gateway"
+        mock_response.json.side_effect = json.JSONDecodeError("Expecting value", "", 0)
+        long_html = "<html>" + ("x" * 2000) + "</html>"
+        mock_response.text = long_html
+
+        with pytest.raises(ScoutAPMAPIError) as exc_info:
+            client._handle_response_errors(mock_response)
+
+        message = str(exc_info.value)
+        assert "502" in message
+        assert "Bad Gateway" in message
+        # Body should be truncated to 500 chars; full 2000-char body must not appear.
+        assert long_html not in message
+        assert exc_info.value.status_code == 502
+
+    def test_handle_response_errors_401_still_raises_auth_error(self):
+        """Regression: 401 must raise ScoutAPMAuthError even with empty body."""
+        client = ScoutAPMAsync("test_key")
+        mock_response = Mock()
+        mock_response.status_code = 401
+        mock_response.json.side_effect = json.JSONDecodeError("Expecting value", "", 0)
+        mock_response.text = ""
+
+        with pytest.raises(ScoutAPMAuthError, match="Authentication failed"):
+            client._handle_response_errors(mock_response)
+
+    def test_handle_response_errors_200_valid_json_passthrough(self):
+        """Regression: 200 with valid JSON returns the parsed payload unchanged."""
+        client = ScoutAPMAsync("test_key")
+        mock_response = Mock()
+        mock_response.status_code = 200
+        payload = {"results": {"apps": [{"id": 1, "name": "test"}]}}
+        mock_response.json.return_value = payload
+
+        result = client._handle_response_errors(mock_response)
+        assert result == payload
+
 
 class TestScoutAPMAsync:
     """Test asynchronous Scout APM client."""


### PR DESCRIPTION
## Summary

Fixes a confusing user-visible error from `mcp__scout-apm__get_app_endpoints` (and any other tool that hits an upstream proxy failure):

```
{"error":"Invalid JSON response: "}
```

(Note the empty content after the colon — the real failure is hidden.)

## Root cause

In `scout_mcp/scout_api.py`, `_handle_response_errors` called `response.json()` *before* inspecting the HTTP status code. When the upstream proxy in front of the Scout APM API times out on a long time window (e.g. 24h+ requests to `/api/v0/apps/:id/endpoints?full=true&from=...&to=...`) it returns a 502/504 with an empty body. `response.json()` raises `json.JSONDecodeError`, the handler formats `f"Invalid JSON response: {response.text}"`, `response.text` is empty, and the actual status code is lost.

## Fix

`_handle_response_errors` now:

1. Checks for 401 first and raises `ScoutAPMAuthError` (preserves existing behavior, including for empty bodies).
2. Attempts `response.json()`. If it fails:
   - For status `>= 400`, raises `ScoutAPMAPIError("Upstream returned <status> <reason> with non-JSON body: <truncated text or '<empty>'>")` so users see the real failure.
   - For 2xx, raises `ScoutAPMAPIError` mentioning the status and a truncated body.
3. Leaves successful (2xx with valid JSON) and Scout-embedded-error paths unchanged.

Body text is truncated to 500 chars to avoid dumping multi-KB HTML error pages into MCP responses.

## Repro

1. Call `get_app_endpoints` with a 24h+ time window against an app with enough data to slow the upstream API.
2. The proxy returns 504 with an empty body.
3. **Before:** `Invalid JSON response: ` (empty, status code hidden).
4. **After:** `Upstream returned 504 Gateway Timeout with non-JSON body: <empty>` and `status_code=504` on the exception.

## Test plan

- [x] New test: 504 with empty body produces a 504-aware error, not "Invalid JSON".
- [x] New test: 502 with a long HTML body produces a 502-aware error and truncates the body.
- [x] Regression test: 401 still raises `ScoutAPMAuthError` even when body is empty/non-JSON.
- [x] Regression test: 200 with valid JSON returns the parsed payload unchanged.
- [x] Full suite (`uv run pytest`) passes — 74 tests.
- [x] `flake8` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)