### PR TITLE
bump version to 2026.5.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "scout-mcp-local"
 maintainers = [
   {name = "Scout Monitoring", email = "support@scoutapm.com"}
 ]
-version = "2026.3.20"
+version = "2026.5.5"
 description = "A local MCP for Scout Monitoring data interactions."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/scoutapp/scout-mcp-local",
     "source": "github"
   },
-  "version": "2026.3.20",
+  "version": "2026.5.5",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "scout-mcp-local",
-      "version": "2026.3.20",
+      "version": "2026.5.5",
       "transport": {
         "type": "stdio"
       },

--- a/uv.lock
+++ b/uv.lock
@@ -947,7 +947,7 @@ wheels = [
 
 [[package]]
 name = "scout-mcp-local"
-version = "2026.3.20"
+version = "2026.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/wizard/package-lock.json
+++ b/wizard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@scout_apm/wizard",
-  "version": "2026.3.20",
+  "version": "2026.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@scout_apm/wizard",
-      "version": "2026.3.20",
+      "version": "2026.5.5",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.7.0",

--- a/wizard/package.json
+++ b/wizard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scout_apm/wizard",
-  "version": "2026.3.20",
+  "version": "2026.5.5",
   "description": "Scout Wizard",
   "main": "dist/scout-wizard.js",
   "repository": "github:scoutapp/scout-mcp-local",


### PR DESCRIPTION
Bumps versions in `pyproject.toml`, `wizard/package.json`, and `server.json` from `2026.3.20` to `2026.5.5` via `bump_versions.py`.

After merge, tag `v2026.5.5` and create a GitHub Release to trigger PyPI / Docker / npm publishing.