### PR TITLE
Add anomaly_events MCP tools

### DIFF
--- a/scout_mcp/scout_api.py
+++ b/scout_mcp/scout_api.py
@@ -42,6 +42,15 @@ VALID_JOB_METRICS = {
     "errors",
     "allocations",
 }
+VALID_ANOMALY_EVENT_STATES = {"open", "closed", "all"}
+VALID_ANOMALY_METRICS = {
+    "response_time",
+    "response_time_p95",
+    "throughput",
+    "error_rate",
+    "job_call_time",
+    "job_throughput",
+}
 
 
 class ScoutAPMError(Exception):
@@ -435,6 +444,52 @@ class ScoutAPMAsync(ScoutAPMBase):
             f"apps/{app_id}/error_groups/{error_group_id}/errors",
         )
         return response.get("results", {}).get("errors", [])
+
+    async def get_anomaly_events(
+        self,
+        app_id: int,
+        duration: Duration,
+        state: Optional[str] = None,
+        metric: Optional[str] = None,
+        endpoint: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """Get anomaly events for an application within a timeframe."""
+        self._validate_time_range(duration)
+        if state is not None and state not in VALID_ANOMALY_EVENT_STATES:
+            raise ValueError(
+                "Invalid state. Must be one of: "
+                + ", ".join(VALID_ANOMALY_EVENT_STATES)
+            )
+        if metric is not None and metric not in VALID_ANOMALY_METRICS:
+            raise ValueError(
+                "Invalid metric. Must be one of: "
+                + ", ".join(VALID_ANOMALY_METRICS)
+            )
+
+        params = self._get_duration_params(duration)
+        if state:
+            params["state"] = state
+        if metric:
+            params["metric"] = metric
+        if endpoint:
+            params["endpoint"] = endpoint
+
+        response = await self._make_request(
+            "GET",
+            f"apps/{app_id}/anomaly_events",
+            params=params,
+        )
+        return response.get("results", {}).get("anomaly_events", [])
+
+    async def get_anomaly_event(
+        self, app_id: int, anomaly_event_id: int
+    ) -> Dict[str, Any]:
+        """Get a single anomaly event including smart_monitor and deploy context."""
+        response = await self._make_request(
+            "GET",
+            f"apps/{app_id}/anomaly_events/{anomaly_event_id}",
+        )
+        return response.get("results", {}).get("anomaly_event", {})
 
     def _get_duration_params(self, duration: Duration) -> Dict[str, str]:
         """Get duration parameters for API requests."""

--- a/scout_mcp/server.py
+++ b/scout_mcp/server.py
@@ -448,15 +448,12 @@ async def get_app_anomaly_events(
     response time spike, throughput drop) detected against a learned baseline.
 
     Args:
-        app_id (int): The ID of the Scout APM application.
-        from_ (str): The start datetime in ISO 8601 format.
-        to (str): The end datetime in ISO 8601 format.
-        state (str | None): Filter by state - "open", "closed", or "all"
-                            (default: server-side, typically "open").
-        metric (str | None): Filter by metric - one of response_time,
-                             response_time_p95, throughput, error_rate,
-                             job_call_time, job_throughput.
-        endpoint (str | None): Filter by endpoint (controller path).
+        app_id: The ID of the Scout APM application.
+        from_: Start datetime in ISO 8601 format.
+        to: End datetime in ISO 8601 format.
+        state: Filter by state - "open", "closed", or "all".
+        metric: Filter by metric (e.g. response_time, throughput, error_rate).
+        endpoint: Filter by endpoint (controller path).
     """
     try:
         duration = scout_api.make_duration(from_, to)
@@ -468,9 +465,7 @@ async def get_app_anomaly_events(
                 metric=metric,
                 endpoint=endpoint,
             )
-    except scout_api.ScoutAPMError as e:
-        return [{"error": str(e)}]
-    except ValueError as e:
+    except (scout_api.ScoutAPMError, ValueError) as e:
         return [{"error": str(e)}]
 
 
@@ -478,14 +473,7 @@ async def get_app_anomaly_events(
 async def get_app_anomaly_event(
     app_id: int, anomaly_event_id: int
 ) -> dict[str, Any]:
-    """
-    Get a single anomaly event by ID, including joined smart_monitor and deploy
-    context.
-
-    Args:
-        app_id (int): The ID of the Scout APM application.
-        anomaly_event_id (int): The ID of the anomaly event to retrieve.
-    """
+    """Get a single anomaly event by ID, with smart_monitor and deploy context."""
     try:
         async with api_client as scout_client:
             return await scout_client.get_anomaly_event(app_id, anomaly_event_id)

--- a/scout_mcp/server.py
+++ b/scout_mcp/server.py
@@ -1,5 +1,5 @@
-import logging
 import json
+import logging
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -430,6 +430,67 @@ async def get_app_error_groups(
         return errors
     except scout_api.ScoutAPMError as e:
         return [{"error": str(e)}]
+
+
+@mcp.tool(name="get_app_anomaly_events")
+async def get_app_anomaly_events(
+    app_id: int,
+    from_: str,
+    to: str,
+    state: str | None = None,
+    metric: str | None = None,
+    endpoint: str | None = None,
+) -> list[dict[str, Any]]:
+    """
+    List anomaly events for a Scout APM application within a timeframe.
+
+    Anomaly events flag statistically significant deviations in a metric (e.g.
+    response time spike, throughput drop) detected against a learned baseline.
+
+    Args:
+        app_id (int): The ID of the Scout APM application.
+        from_ (str): The start datetime in ISO 8601 format.
+        to (str): The end datetime in ISO 8601 format.
+        state (str | None): Filter by state - "open", "closed", or "all"
+                            (default: server-side, typically "open").
+        metric (str | None): Filter by metric - one of response_time,
+                             response_time_p95, throughput, error_rate,
+                             job_call_time, job_throughput.
+        endpoint (str | None): Filter by endpoint (controller path).
+    """
+    try:
+        duration = scout_api.make_duration(from_, to)
+        async with api_client as scout_client:
+            return await scout_client.get_anomaly_events(
+                app_id,
+                duration,
+                state=state,
+                metric=metric,
+                endpoint=endpoint,
+            )
+    except scout_api.ScoutAPMError as e:
+        return [{"error": str(e)}]
+    except ValueError as e:
+        return [{"error": str(e)}]
+
+
+@mcp.tool(name="get_app_anomaly_event")
+async def get_app_anomaly_event(
+    app_id: int, anomaly_event_id: int
+) -> dict[str, Any]:
+    """
+    Get a single anomaly event by ID, including joined smart_monitor and deploy
+    context.
+
+    Args:
+        app_id (int): The ID of the Scout APM application.
+        anomaly_event_id (int): The ID of the anomaly event to retrieve.
+    """
+    try:
+        async with api_client as scout_client:
+            return await scout_client.get_anomaly_event(app_id, anomaly_event_id)
+    except scout_api.ScoutAPMError as e:
+        return {"error": str(e)}
 
 
 @mcp.tool(name="get_usage")

--- a/tests/scout_mcp/test_scout_api.py
+++ b/tests/scout_mcp/test_scout_api.py
@@ -984,6 +984,8 @@ class TestAnomalyEvents:
                         "id": 7,
                         "name": "Users index latency",
                         "kind": "response_time",
+                        "severity_threshold": 4.0,
+                        "duration_minutes": 1,
                     },
                     "deploy": {
                         "id": 99,

--- a/tests/scout_mcp/test_scout_api.py
+++ b/tests/scout_mcp/test_scout_api.py
@@ -878,6 +878,142 @@ class TestScoutAPMAsync:
                 await client.get_job_traces(1, "RW1haWxKb2I=", duration)
 
 
+class TestAnomalyEvents:
+    """Test anomaly events methods."""
+
+    @pytest.fixture
+    def client(self):
+        return ScoutAPMAsync("test_key")
+
+    @pytest.mark.asyncio
+    async def test_get_anomaly_events_basic(self, client):
+        """Test get_anomaly_events with no optional filters."""
+        mock_response = {
+            "results": {
+                "anomaly_events": [
+                    {
+                        "id": 1,
+                        "metric": "response_time",
+                        "endpoint": "UsersController#index",
+                        "direction": "up",
+                        "severity": "high",
+                        "open": True,
+                    }
+                ]
+            }
+        }
+        duration = make_duration("2024-01-01T00:00:00Z", "2024-01-02T00:00:00Z")
+
+        with patch.object(
+            client, "_make_request", return_value=mock_response
+        ) as mock_request:
+            events = await client.get_anomaly_events(1, duration)
+
+            mock_request.assert_called_once_with(
+                "GET",
+                "apps/1/anomaly_events",
+                params={
+                    "from": "2024-01-01T00:00:00Z",
+                    "to": "2024-01-02T00:00:00Z",
+                },
+            )
+            assert len(events) == 1
+            assert events[0]["metric"] == "response_time"
+
+    @pytest.mark.asyncio
+    async def test_get_anomaly_events_with_filters(self, client):
+        """Test get_anomaly_events with all optional filters."""
+        mock_response = {"results": {"anomaly_events": []}}
+        duration = make_duration("2024-01-01T00:00:00Z", "2024-01-02T00:00:00Z")
+
+        with patch.object(
+            client, "_make_request", return_value=mock_response
+        ) as mock_request:
+            result = await client.get_anomaly_events(
+                1,
+                duration,
+                state="open",
+                metric="response_time",
+                endpoint="UsersController#index",
+            )
+            assert result == []
+            mock_request.assert_called_once_with(
+                "GET",
+                "apps/1/anomaly_events",
+                params={
+                    "from": "2024-01-01T00:00:00Z",
+                    "to": "2024-01-02T00:00:00Z",
+                    "state": "open",
+                    "metric": "response_time",
+                    "endpoint": "UsersController#index",
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_get_anomaly_events_invalid_state(self, client):
+        """Invalid state should raise ValueError."""
+        duration = make_duration("2024-01-01T00:00:00Z", "2024-01-02T00:00:00Z")
+        with pytest.raises(ValueError, match="Invalid state"):
+            await client.get_anomaly_events(1, duration, state="bogus")
+
+    @pytest.mark.asyncio
+    async def test_get_anomaly_events_invalid_metric(self, client):
+        """Invalid metric should raise ValueError."""
+        duration = make_duration("2024-01-01T00:00:00Z", "2024-01-02T00:00:00Z")
+        with pytest.raises(ValueError, match="Invalid metric"):
+            await client.get_anomaly_events(1, duration, metric="apdex")
+
+    @pytest.mark.asyncio
+    async def test_get_anomaly_events_empty_results(self, client):
+        """Test get_anomaly_events with empty results."""
+        duration = make_duration("2024-01-01T00:00:00Z", "2024-01-02T00:00:00Z")
+        with patch.object(client, "_make_request", return_value={"results": {}}):
+            events = await client.get_anomaly_events(1, duration)
+            assert events == []
+
+    @pytest.mark.asyncio
+    async def test_get_anomaly_event(self, client):
+        """Test get_anomaly_event method."""
+        mock_response = {
+            "results": {
+                "anomaly_event": {
+                    "id": 42,
+                    "metric": "response_time",
+                    "endpoint": "UsersController#index",
+                    "smart_monitor": {
+                        "id": 7,
+                        "name": "Users index latency",
+                        "kind": "response_time",
+                    },
+                    "deploy": {
+                        "id": 99,
+                        "sha": "abc123",
+                        "deployed_at": "2024-01-01T00:00:00Z",
+                    },
+                }
+            }
+        }
+
+        with patch.object(
+            client, "_make_request", return_value=mock_response
+        ) as mock_request:
+            event = await client.get_anomaly_event(1, 42)
+
+            mock_request.assert_called_once_with(
+                "GET", "apps/1/anomaly_events/42"
+            )
+            assert event["id"] == 42
+            assert event["smart_monitor"]["name"] == "Users index latency"
+            assert event["deploy"]["sha"] == "abc123"
+
+    @pytest.mark.asyncio
+    async def test_get_anomaly_event_empty_results(self, client):
+        """Test get_anomaly_event with empty results."""
+        with patch.object(client, "_make_request", return_value={"results": {}}):
+            event = await client.get_anomaly_event(1, 42)
+            assert event == {}
+
+
 class TestGetUsage:
     """Test get_usage method."""
 

--- a/tests/scout_mcp/test_server.py
+++ b/tests/scout_mcp/test_server.py
@@ -288,6 +288,7 @@ class TestGetAppAnomalyEvent:
             "metric": "response_time",
             "smart_monitor": {
                 "id": 7, "name": "Users latency", "kind": "response_time",
+                "severity_threshold": 4.0, "duration_minutes": 1,
             },
             "deploy": {
                 "id": 99, "sha": "abc123", "deployed_at": "2024-01-01T00:00:00Z",

--- a/tests/scout_mcp/test_server.py
+++ b/tests/scout_mcp/test_server.py
@@ -203,6 +203,118 @@ class TestGetAppJobTraces:
             assert result[0]["error"] == "API error"
 
 
+class TestGetAppAnomalyEvents:
+    @pytest.mark.asyncio
+    async def test_get_app_anomaly_events_success(self):
+        mock_events = [
+            {
+                "id": 1,
+                "metric": "response_time",
+                "endpoint": "UsersController#index",
+                "direction": "up",
+                "severity": "high",
+                "open": True,
+            }
+        ]
+
+        with patch.object(
+            scout_api.ScoutAPMAsync,
+            "get_anomaly_events",
+            new_callable=AsyncMock,
+            return_value=mock_events,
+        ) as mock_method:
+            result = await server.get_app_anomaly_events(
+                1, "2024-01-01T00:00:00Z", "2024-01-02T00:00:00Z"
+            )
+
+            assert len(result) == 1
+            assert result[0]["metric"] == "response_time"
+            # Confirm a Duration object was constructed and passed
+            args, kwargs = mock_method.call_args
+            assert args[0] == 1
+            assert isinstance(args[1], scout_api.Duration)
+
+    @pytest.mark.asyncio
+    async def test_get_app_anomaly_events_with_filters(self):
+        with patch.object(
+            scout_api.ScoutAPMAsync,
+            "get_anomaly_events",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as mock_method:
+            await server.get_app_anomaly_events(
+                1,
+                "2024-01-01T00:00:00Z",
+                "2024-01-02T00:00:00Z",
+                state="open",
+                metric="response_time",
+                endpoint="UsersController#index",
+            )
+            kwargs = mock_method.call_args.kwargs
+            assert kwargs["state"] == "open"
+            assert kwargs["metric"] == "response_time"
+            assert kwargs["endpoint"] == "UsersController#index"
+
+    @pytest.mark.asyncio
+    async def test_get_app_anomaly_events_api_error(self):
+        with patch.object(
+            scout_api.ScoutAPMAsync,
+            "get_anomaly_events",
+            new_callable=AsyncMock,
+            side_effect=scout_api.ScoutAPMAPIError("API error"),
+        ):
+            result = await server.get_app_anomaly_events(
+                1, "2024-01-01T00:00:00Z", "2024-01-02T00:00:00Z"
+            )
+            assert result[0]["error"] == "API error"
+
+    @pytest.mark.asyncio
+    async def test_get_app_anomaly_events_invalid_state(self):
+        result = await server.get_app_anomaly_events(
+            1,
+            "2024-01-01T00:00:00Z",
+            "2024-01-02T00:00:00Z",
+            state="bogus",
+        )
+        assert "error" in result[0]
+        assert "Invalid state" in result[0]["error"]
+
+
+class TestGetAppAnomalyEvent:
+    @pytest.mark.asyncio
+    async def test_get_app_anomaly_event_success(self):
+        mock_event = {
+            "id": 42,
+            "metric": "response_time",
+            "smart_monitor": {
+                "id": 7, "name": "Users latency", "kind": "response_time",
+            },
+            "deploy": {
+                "id": 99, "sha": "abc123", "deployed_at": "2024-01-01T00:00:00Z",
+            },
+        }
+        with patch.object(
+            scout_api.ScoutAPMAsync,
+            "get_anomaly_event",
+            new_callable=AsyncMock,
+            return_value=mock_event,
+        ):
+            result = await server.get_app_anomaly_event(1, 42)
+            assert result["id"] == 42
+            assert result["smart_monitor"]["name"] == "Users latency"
+
+    @pytest.mark.asyncio
+    async def test_get_app_anomaly_event_error(self):
+        with patch.object(
+            scout_api.ScoutAPMAsync,
+            "get_anomaly_event",
+            new_callable=AsyncMock,
+            side_effect=scout_api.ScoutAPMAPIError("API error"),
+        ):
+            result = await server.get_app_anomaly_event(1, 42)
+            assert result["error"] == "API error"
+
+
 class TestGetUsageTool:
     """Tests for the get_usage MCP tool."""
 


### PR DESCRIPTION
## Summary

- Adds `get_app_anomaly_events` and `get_app_anomaly_event` MCP tools
- Wraps the new Scout APM anomaly events API endpoints

Closes #79

## Test plan

- [x] `uv run task check`
- [ ] Manual: call `get_app_anomaly_events` against a Scout app with anomaly events
- [ ] Manual: call `get_app_anomaly_event` with a known event ID

Generated with [Claude Code](https://claude.com/claude-code)